### PR TITLE
Added missing start() command on kotlin test

### DIFF
--- a/src/test/kotlin/it/robfrank/testcontainers/KotlinSimpleQueryTest.kt
+++ b/src/test/kotlin/it/robfrank/testcontainers/KotlinSimpleQueryTest.kt
@@ -17,6 +17,8 @@ class KotlinSimpleQueryTest {
     @Test
     fun `should perform simple query`() {
 
+        container.start()
+
         DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { conn ->
 
             conn.createStatement().use { stmt ->


### PR DESCRIPTION
Hello Rob :smiley:,
I am in the process of learning about testcontainers and came across your repo on the subject. But when I  run the test [KotlinSimpleQueryTest.kt](https://github.com/robfrank/testcontainers-examples/blob/master/src/test/kotlin/it/robfrank/testcontainers/KotlinSimpleQueryTest.kt) i have an issue as below:

```
java.lang.IllegalStateException: Mapped port can only be obtained after the container is started

	at org.testcontainers.shaded.com.google.common.base.Preconditions.checkState(Preconditions.java:174)
``` 

So, we should first start the container to be ready to mapping ports etc.. right?

Let me know what do you think,
Thanks!